### PR TITLE
➕[Feat] 친구 요청 API 추가

### DIFF
--- a/server/src/controller/friend.js
+++ b/server/src/controller/friend.js
@@ -3,7 +3,7 @@ const service = require('../service/friend');
 
 // 친구 검색
 const getSearchFriendController = (req, res) => {
-  const dto = { friendEmail: req.query.email };
+  const dto = { userEmail: req.user.user_email, friendEmail: req.query.email };
   if (!dto.friendEmail) {
     res.status(statusCode.BAD_REQUEST).send('Bad Request');
   }
@@ -33,7 +33,63 @@ const getFriendListController = (req, res) => {
   });
 };
 
+// 친구 요청 조회
+const getFriendRequestController = (req, res) => {
+  const dto = { userEmail: req.user.user_email };
+  if (!dto.userEmail) {
+    res.status(statusCode.UNAUTHORIZED).send('Unauthorized');
+  }
+
+  service.getFriendRequestService(dto, (err, data) => {
+    if (err) {
+      res.status(statusCode.INTERNAL_SERVER_ERROR).send(err);
+    } else {
+      res.status(statusCode.OK).send(data);
+    }
+  });
+};
+
+// 친구 요청 보내기
+const postFriendRequestController = (req, res) => {
+  const dto = { userEmail: req.user.user_email, friendEmail: req.query.email };
+  if (!dto.userEmail | !dto.friendEmail) {
+    res.status(statusCode.UNAUTHORIZED).send('Unauthorized');
+  }
+
+  service.postFriendRequestService(dto, (err, data) => {
+    if (err) {
+      res.status(statusCode.INTERNAL_SERVER_ERROR).send(err);
+    } else {
+      res.status(statusCode.OK);
+    }
+  });
+};
+
+// 친구 수락
+const putFriendRequestController = (req, res) => {
+  const dto = {
+    userEmail: req.user.user_email,
+    friendEmail: req.query.email,
+    state: parseInt(req.query.state),
+  };
+  console.log(dto);
+  if (!dto.userEmail | !dto.friendEmail | !dto.state) {
+    res.status(statusCode.UNAUTHORIZED).send('Unauthorized');
+  }
+
+  service.putFriendRequestService(dto, (err, data) => {
+    if (err) {
+      res.status(statusCode.INTERNAL_SERVER_ERROR).send(err);
+    } else {
+      res.status(statusCode.OK);
+    }
+  });
+};
+
 module.exports = {
   getSearchFriendController,
   getFriendListController,
+  getFriendRequestController,
+  postFriendRequestController,
+  putFriendRequestController,
 };

--- a/server/src/dao/friend.js
+++ b/server/src/dao/friend.js
@@ -17,6 +17,23 @@ const getSearchFriendDao = (dto, callback) => {
   );
 };
 
+// 친구 상태 조회
+const getFriendStateDao = (dto, callback) => {
+  db.query(
+    `
+    SELECT state FROM friendrequest WHERE send_email = ? AND receive_email = ?
+    `,
+    [dto.userEmail, dto.friendEmail],
+    (err, rows, fields) => {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, rows[0]);
+      }
+    },
+  );
+};
+
 // 친구 리스트 조회
 const getFriendListDao = (dto, callback) => {
   db.query(
@@ -36,7 +53,82 @@ const getFriendListDao = (dto, callback) => {
   );
 };
 
+// 친구 요청 조회
+const getFriendRequestDao = (dto, callback) => {
+  db.query(
+    `
+    SELECT u.user_email, u.user_name FROM user u \
+    INNER JOIN friendrequest f ON u.user_email = f.send_email \
+    WHERE f.receive_email = ? AND state = 0
+    `,
+    [dto.userEmail],
+    (err, rows, fields) => {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, rows);
+      }
+    },
+  );
+};
+
+// 친구 요청 보내기
+const postFriendRequestDao = (dto, callback) => {
+  db.query(
+    `
+    INSERT INTO friendrequest(send_email, receive_email) VALUES(?, ?)
+    `,
+    [dto.userEmail, dto.friendEmail],
+    (err, rows, fields) => {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, rows);
+      }
+    },
+  );
+};
+
+// 친구 수락
+const putFriendRequestDao = (dto, callback) => {
+  db.query(
+    `
+    UPDATE friendrequest SET state = ? WHERE send_email = ? AND receive_email = ?
+    `,
+    [dto.state, dto.friendEmail, dto.userEmail],
+    (err, rows, fields) => {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, rows);
+      }
+    },
+  );
+};
+
+// 친구 수락시 친구 추가
+const postFriendDao = (dto, callback) => {
+  db.query(
+    `
+    INSERT INTO friend(user_email, friend_email) VALUES(?, ?)
+    `,
+    [dto.friendEmail, dto.userEmail, dto.userEmail, dto.friendEmail],
+    (err, rows, fields) => {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, rows);
+      }
+    },
+  );
+};
+
 module.exports = {
+  getFriendStateDao,
   getSearchFriendDao,
   getFriendListDao,
+  getFriendRequestDao,
+  postFriendRequestDao,
+  putFriendRequestDao,
+  postFriendDao,
 };

--- a/server/src/route/friend.js
+++ b/server/src/route/friend.js
@@ -4,5 +4,8 @@ const controller = require('../controller/friend');
 
 router.get('/search', controller.getSearchFriendController);
 router.get('/list', controller.getFriendListController);
+router.get('/request', controller.getFriendRequestController);
+router.post('/request', controller.postFriendRequestController);
+router.put('/request', controller.putFriendRequestController);
 
 module.exports = router;

--- a/server/src/service/friend.js
+++ b/server/src/service/friend.js
@@ -2,8 +2,17 @@ const dao = require('../dao/friend');
 
 // 친구 검색
 const getSearchFriendService = (dto, callback) => {
+  let state;
   dao.getSearchFriendDao(dto, function (err, data) {
-    return callback(err, data);
+    if (err) return callback(err, data);
+    this.data = data;
+  });
+  dao.getFriendStateDao(dto, function (err, data) {
+    if (err) return callback(err, data);
+    if (data === undefined) state = -1;
+    else state = data['state'];
+    this.data['state'] = state;
+    return callback(err, this.data);
   });
 };
 
@@ -14,7 +23,37 @@ const getFriendListService = (dto, callback) => {
   });
 };
 
+// 친구 요청 조회
+const getFriendRequestService = (dto, callback) => {
+  dao.getFriendRequestDao(dto, function (err, data) {
+    return callback(err, data);
+  });
+};
+
+// 친구 요청 보내기
+const postFriendRequestService = (dto, callback) => {
+  dao.postFriendRequestDao(dto, function (err, data) {
+    return callback(err, data);
+  });
+};
+
+// 친구 수락
+const putFriendRequestService = (dto, callback) => {
+  dao.putFriendRequestDao(dto, function (err, data) {
+    if (dto.state === 1) {
+      dao.postFriendDao(dto, function (err, data) {
+        return callback(err, data);
+      });
+    } else {
+      return callback(err, data);
+    }
+  });
+};
+
 module.exports = {
   getSearchFriendService,
   getFriendListService,
+  getFriendRequestService,
+  postFriendRequestService,
+  putFriendRequestService,
 };


### PR DESCRIPTION
## **⚡ Content**

- [x]  친구 검색 `GET`
    - table : `user`
    - request : `user_email`
    - response : `user 정보 전체` + `state`

- 현재 친구 상태인지, 친구 요청 보낸 상태인지도 같이 띄워줘야함
    - state
        - 아무 상태 아님 : -1
        - 친구 요청 보낸 상태 : 0
        - 현재 친구 상태 : 1
- [x]  친구 리스트 조회 `GET` : 내 친구들 정보 띄움
    - table : user, friend
    - request : x
        - *`user_id` → serialize로 자동으로 받아옴*
    - response: user_email, user_name
- [x]  친구 요청 보내기 `POST`
    - table : friendrequest
    - request : `receive_email`
        - `send_email` *→ serialize로 자동으로 받아옴*
    - response: x
- [x]  친구 요청 조회 `GET` : 일종의 버킷 역할!
    - table : user, friend
    - request : x
        - *`user_id` → serialize로 자동으로 받아옴*
    - response: user_email, user_name

## **📆 TBD**

- [ ]  친구 수락 `PUT`
    - 친구 상태
        - None : 0
        - 수락 : 1
        - 거절 : 2
- [ ]  친구 삭제 `DELETE`
